### PR TITLE
Add accessibility settings button on screen

### DIFF
--- a/puppet/app/src/main/java/com/ttt246/puppet/ChatterAct.kt
+++ b/puppet/app/src/main/java/com/ttt246/puppet/ChatterAct.kt
@@ -1,6 +1,7 @@
 package com.ttt246.puppet
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.preference.PreferenceManager
@@ -11,13 +12,18 @@ import androidx.appcompat.app.AppCompatActivity
 
 class ChatterAct : AppCompatActivity() {
     private lateinit var webView: WebView
+    private val TAG = "ChatterActLog"
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
         supportActionBar?.hide()
-        val intent = Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS)
-        startActivity(intent)
+
+        val accessibilitySettingsBtn: Button = findViewById(R.id.accessibilitySettings)
+        accessibilitySettingsBtn.setOnClickListener {
+            val intent = Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS)
+            startActivity(intent)
+        }
 
         val settingsButton: Button = findViewById(R.id.settingsButton)
         webView = findViewById(R.id.webView)

--- a/puppet/app/src/main/res/layout/activity_main.xml
+++ b/puppet/app/src/main/res/layout/activity_main.xml
@@ -3,13 +3,28 @@
     android:layout_height="match_parent">
 
     <Button
+        android:id="@+id/accessibilitySettings"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentEnd="true"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="214dp"
+        android:layout_marginBottom="16dp"
+        android:text="Enable Accessibility" />
+
+    <Button
         android:id="@+id/settingsButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Settings"
-        android:layout_alignParentEnd="true"
         android:layout_alignParentTop="true"
-        android:layout_margin="16dp" />
+        android:layout_alignParentEnd="true"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp"
+        android:text="Settings" />
 
     <WebView
         android:id="@+id/webView"


### PR DESCRIPTION
Launching Android's settings activity everytime we launch the app is problematic when we often resume the app. Placed an explicit button to indicate to switch to the settings activity. Makes the tests deterministic too.