### PR TITLE
Add switch command to switch to instructed package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 **/*.swp
 **/*.env
+__pycache__
 .vscode
 puppet.db
 node_modules/
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/*.swp
+**/*.env
 .vscode
 puppet.db
 node_modules/

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ A next generation cloud operating system with legacy integration
 
 This repo also allows you to drive an android machine as easily as the web. I was inspired by https://github.com/nat/natbot/blob/main/natbot.py, but this is for android instead of the web. It uses acceesibility to see, and additionally Android Intents to steer. Sometimes it needs the users' help because of android's security model. 
 
-
 This is a 3 part system
 - [puppet](puppet/README.md) The android app
 - [backend](backend/README.md) A simple python backend

--- a/e2e_tests/README.md
+++ b/e2e_tests/README.md
@@ -16,3 +16,5 @@ For local machine, an appium server, android emulator and Java SDK is required.
 `pip install -r requirements.txt`
 
 `python test_sauce_labs.py`
+
+While running locally, you can create a .env file inside e2e_tests folder and place your environment variables.

--- a/e2e_tests/requirements.txt
+++ b/e2e_tests/requirements.txt
@@ -1,1 +1,2 @@
 Appium-Python-Client==2.11.1
+python-dotenv==1.0.0

--- a/e2e_tests/test_sauce_labs.py
+++ b/e2e_tests/test_sauce_labs.py
@@ -7,13 +7,23 @@ import os
 from appium import webdriver
 from appium.webdriver.common.appiumby import AppiumBy
 from selenium.webdriver.remote.webdriver import WebDriver
+from dotenv import load_dotenv
 
-APPIUM_PORT = 4723
-APPIUM_HOST = "127.0.0.1"
+load_dotenv()
 
+# SAUCE LABS Specific configuration
 SAUCE_USERNAME = os.getenv("SAUCE_USERNAME")
 SAUCE_ACCESS_KEY = os.getenv("SAUCE_ACCESS_KEY")
 TEST_UUID = os.getenv("TEST_UUID", "")
+BUILD_STAGE = os.getenv("BUILD_STAGE", "DEV")
+
+# Sauce labs URL
+APPIUM_SERVER_URL = "http://127.0.0.1:4723"
+SAUCE_LABS_URL = "https://ondemand.us-west-1.saucelabs.com:443/wd/hub"
+
+# Android specific application
+APP_PACKAGE_NAME = "com.ttt246.puppet"
+APP_ACTIVITY_NAME = ".ChatterAct"
 
 
 def create_android_driver(sauce_labs=False):
@@ -21,60 +31,77 @@ def create_android_driver(sauce_labs=False):
         platformName="Android",
         automationName="uiautomator2",
         deviceName="Android",
-        appPackage="com.ttt246.puppet",
-        appActivity=".ChatterAct",
+        appPackage=APP_PACKAGE_NAME,
+        appActivity=APP_ACTIVITY_NAME,
         language="en",
         locale="US",
     )
-    capabilities["appium:app"] = "app-release-unsigned.apk"
-    capabilities["autoGrantPermissions"] = "true"
-    connection_url = f"http://{APPIUM_HOST}:{APPIUM_PORT}"
+
+    capabilities["appium:autoGrantPermissions"] = "true"
+    capabilities["appium:autoAcceptAlerts"] = "true"
+    capabilities["appium:automationName"] = "uiautomator2"
+
     if sauce_labs:
-        capabilities["platformName"] = "Android"
-        capabilities["appium:app"] = "storage:filename=app-release-unsigned.apk"
-        capabilities["appium:deviceName"] = "Android GoogleAPI Emulator"
         capabilities["appium:deviceOrientation"] = "portrait"
         capabilities["appium:platformVersion"] = "13.0"
-        capabilities["appium:automationName"] = "uiautomator2"
-        capabilities["appPackage"] = "com.ttt246.puppet"
-        capabilities["appActivity"] = ".ChatterAct"
-        capabilities["appium:autoGrantPermissions"] = "true"
         capabilities["sauce:options"] = {}
         capabilities["sauce:options"]["username"] = SAUCE_USERNAME
         capabilities["sauce:options"]["accessKey"] = SAUCE_ACCESS_KEY
-        capabilities["sauce:options"]["build"] = "appium-build-HGNZD"
-        capabilities["sauce:options"]["name"] = "Automate Tests"
+        capabilities["sauce:options"]["build"] = f"puppet-build-{BUILD_STAGE}"
+        capabilities["sauce:options"]["name"] = "Test Android"
         capabilities["appium:app"] = "storage:filename=app-release-unsigned.apk"
         capabilities["appium:deviceName"] = "Android GoogleAPI Emulator"
 
         connection_url = "https://ondemand.us-west-1.saucelabs.com:443/wd/hub"
+    else:
+        connection_url = APPIUM_SERVER_URL
+
 
     return webdriver.Remote(connection_url, capabilities)
 
 
 @contextmanager
 def android_driver(options):
-    # prefer this fixture if there is no need to customize driver options in tests
     driver = create_android_driver(sauce_labs=True)
+    driver.implicitly_wait(10)
     yield driver
     driver.quit()
 
 
 def save_server_settings(driver: WebDriver):
-    el8 = driver.find_element(
-        by=AppiumBy.ID, value="com.ttt246.puppet:id/settingsButton"
+    element = driver.find_element(
+        by=AppiumBy.ID, value=f"{APP_PACKAGE_NAME}:id/settingsButton"
     )
-    el8.click()
-    el9 = driver.find_element(
-        by=AppiumBy.ID, value="com.ttt246.puppet:id/serverUrlEditText"
+    element.click()
+    element = driver.find_element(
+        by=AppiumBy.ID, value=f"{APP_PACKAGE_NAME}:id/serverUrlEditText"
     )
-    el9.send_keys("https://posix4e-puppet.hf.space")
-    el10 = driver.find_element(
-        by=AppiumBy.ID, value="com.ttt246.puppet:id/uuidEditText"
+    element.send_keys("https://posix4e-puppet.hf.space")
+    element = driver.find_element(
+        by=AppiumBy.ID, value=f"{APP_PACKAGE_NAME}:id/uuidEditText"
     )
-    el10.send_keys("1608052e-b294-4a6f-a69f-e18c9bedf5c8")
-    el11 = driver.find_element(by=AppiumBy.ID, value="com.ttt246.puppet:id/saveButton")
-    el11.click()
+    element.send_keys(TEST_UUID)
+    element = driver.find_element(
+        by=AppiumBy.ID, value="com.ttt246.puppet:id/saveButton"
+    )
+    element.click()
+
+
+def wait_for_element(
+    driver: WebDriver, by_selector: str, selector_value: str, timeout: int = 2
+):
+    from selenium.webdriver.support.wait import WebDriverWait
+    from selenium.webdriver.support import expected_conditions as EC
+
+    try:
+        element = WebDriverWait(driver, timeout).until(
+            EC.presence_of_element_located((by_selector, selector_value))
+        )
+
+    except:
+        element = None
+    finally:
+        return element
 
 
 def enable_privacy_settings(driver: WebDriver):
@@ -86,10 +113,9 @@ def enable_privacy_settings(driver: WebDriver):
     # Use Puppet button
     if not primary_checkbox.get_attribute("checked") == "true":
         primary_checkbox.click()
-        try:
-            driver.find_element(by=AppiumBy.XPATH, value="//*[@text='Allow']").click()
-        except Exception as e:
-            pass
+        element = wait_for_element(driver, AppiumBy.XPATH, "//*[@text='Allow']")
+        if element:
+            element.click()
 
     # Puppet shortcut button
     secondary_checkbox = driver.find_element(
@@ -97,47 +123,43 @@ def enable_privacy_settings(driver: WebDriver):
     )
     if not secondary_checkbox.get_attribute("checked") == "true":
         secondary_checkbox.click()
-        try:
-            driver.find_element(by=AppiumBy.XPATH, value="//*[@text='Got it']").click()
-        except Exception as e:
-            pass
 
-    time.sleep(2)
+    # driver.start_activity(APP_PACKAGE_NAME, APP_ACTIVITY_NAME)
+    # driver.activate_app("com.ttt246.puppet")
+    # These sleeps are harsh, however are now needed till will fix the activity which brings up settings by default
+    # Once thats fixed, we can activate the app back it should resume as is, without the back button
+
     driver.back()
-    time.sleep(2)
+    time.sleep(1)
     driver.back()
+    time.sleep(1)
 
 
 class TestAppium(unittest.TestCase):
     def test_tab_4(self):
-        import time
-
         # Usage of the context manager ensures the driver session is closed properly
         # after the test completes. Otherwise, make sure to call `driver.quit()` on teardown.
         with android_driver({}) as driver:
-            driver.implicitly_wait(10)
-
             enable_privacy_settings(driver)
 
-            driver.activate_app("com.ttt246.puppet")
-            driver.wait_activity(".ChatterAct", 5)
-            time.sleep(2)
+            driver.wait_activity(APP_ACTIVITY_NAME, 5)
 
             save_server_settings(driver)
 
-            el14 = driver.find_element(by=AppiumBy.XPATH, value='//*[@text="Tab 4"]')
-            el14.click()
-            el15 = driver.find_element(
+            element = driver.find_element(by=AppiumBy.XPATH, value='//*[@text="Tab 4"]')
+            element.click()
+            element = driver.find_element(
                 by=AppiumBy.XPATH, value="//android.widget.EditText[@hint='UID']"
             )
-            el15.send_keys(TEST_UUID)
-            el16 = driver.find_element(
+            element.send_keys(TEST_UUID)
+            element = driver.find_element(
                 by=AppiumBy.XPATH, value="//android.widget.EditText[@hint='Command']"
             )
-            el16.send_keys("test")
-            el17 = driver.find_element(by=AppiumBy.XPATH, value='//*[@text="Submit"]')
-            el17.click()
-            time.sleep(5)
+            element.send_keys("test")
+            element = driver.find_element(
+                by=AppiumBy.XPATH, value='//*[@text="Submit"]'
+            )
+            element.click()
 
 
 if __name__ == "__main__":

--- a/e2e_tests/test_sauce_labs.py
+++ b/e2e_tests/test_sauce_labs.py
@@ -8,6 +8,7 @@ from appium import webdriver
 from appium.webdriver.common.appiumby import AppiumBy
 from selenium.webdriver.remote.webdriver import WebDriver
 from dotenv import load_dotenv
+from utils import wait_for_element, find_and_click
 
 load_dotenv()
 
@@ -56,7 +57,6 @@ def create_android_driver(sauce_labs=False):
     else:
         connection_url = APPIUM_SERVER_URL
 
-
     return webdriver.Remote(connection_url, capabilities)
 
 
@@ -69,10 +69,11 @@ def android_driver(options):
 
 
 def save_server_settings(driver: WebDriver):
-    element = driver.find_element(
-        by=AppiumBy.ID, value=f"{APP_PACKAGE_NAME}:id/settingsButton"
+    element = find_and_click(
+        driver,
+        by_selector=AppiumBy.ID,
+        selector_value=f"{APP_PACKAGE_NAME}:id/settingsButton",
     )
-    element.click()
     element = driver.find_element(
         by=AppiumBy.ID, value=f"{APP_PACKAGE_NAME}:id/serverUrlEditText"
     )
@@ -81,31 +82,19 @@ def save_server_settings(driver: WebDriver):
         by=AppiumBy.ID, value=f"{APP_PACKAGE_NAME}:id/uuidEditText"
     )
     element.send_keys(TEST_UUID)
-    element = driver.find_element(
-        by=AppiumBy.ID, value=f"{APP_PACKAGE_NAME}:id/saveButton"
+    element = find_and_click(
+        driver,
+        by_selector=AppiumBy.ID,
+        selector_value=f"{APP_PACKAGE_NAME}:id/saveButton",
     )
-    element.click()
-
-
-def wait_for_element(
-    driver: WebDriver, by_selector: str, selector_value: str, timeout: int = 2
-):
-    from selenium.webdriver.support.wait import WebDriverWait
-    from selenium.webdriver.support import expected_conditions as EC
-
-    try:
-        element = WebDriverWait(driver, timeout).until(
-            EC.presence_of_element_located((by_selector, selector_value))
-        )
-
-    except:
-        element = None
-    finally:
-        return element
 
 
 def enable_privacy_settings(driver: WebDriver):
-    driver.find_element(by=AppiumBy.XPATH, value='//*[@text="puppet"]').click()
+    element = find_and_click(
+        driver,
+        by_selector=AppiumBy.XPATH,
+        selector_value=f"//*[@text='puppet']",
+    )
     primary_checkbox = driver.find_element(
         by=AppiumBy.ID, value="android:id/switch_widget"
     )

--- a/e2e_tests/test_sauce_labs.py
+++ b/e2e_tests/test_sauce_labs.py
@@ -89,7 +89,12 @@ def save_server_settings(driver: WebDriver):
     )
 
 
-def enable_privacy_settings(driver: WebDriver):
+def enable_accessibility_settings(driver: WebDriver):
+    element = find_and_click(
+        driver,
+        by_selector=AppiumBy.ID,
+        selector_value=f"{APP_PACKAGE_NAME}:id/accessibilitySettings"
+    )
     element = find_and_click(
         driver,
         by_selector=AppiumBy.XPATH,
@@ -113,16 +118,20 @@ def enable_privacy_settings(driver: WebDriver):
     if not secondary_checkbox.get_attribute("checked") == "true":
         secondary_checkbox.click()
 
-    # driver.start_activity(APP_PACKAGE_NAME, APP_ACTIVITY_NAME)
+    driver.back()
+
+    driver.start_activity(APP_PACKAGE_NAME, ".ChatterAct")
+    driver.wait_activity(".ChatterAct", 5)
+
     # driver.activate_app(f"{APP_PACKAGE_NAME}")
     # These sleeps are harsh, however are now needed till will fix the activity which brings up settings by default
     # Once thats fixed, we can activate the app back it should resume as is, without the back button
 
-    time.sleep(1)
-    driver.back()
-    time.sleep(1)
-    driver.back()
-    time.sleep(1)
+    # time.sleep(1)
+    # driver.back()
+    # time.sleep(1)
+    # driver.back()
+    # time.sleep(1)
 
 
 class TestAppium(unittest.TestCase):
@@ -130,9 +139,7 @@ class TestAppium(unittest.TestCase):
         # Usage of the context manager ensures the driver session is closed properly
         # after the test completes. Otherwise, make sure to call `driver.quit()` on teardown.
         with android_driver({}) as driver:
-            enable_privacy_settings(driver)
-
-            driver.wait_activity(APP_ACTIVITY_NAME, 5)
+            enable_accessibility_settings(driver)
 
             save_server_settings(driver)
 

--- a/e2e_tests/test_sauce_labs.py
+++ b/e2e_tests/test_sauce_labs.py
@@ -82,7 +82,7 @@ def save_server_settings(driver: WebDriver):
     )
     element.send_keys(TEST_UUID)
     element = driver.find_element(
-        by=AppiumBy.ID, value="com.ttt246.puppet:id/saveButton"
+        by=AppiumBy.ID, value=f"{APP_PACKAGE_NAME}:id/saveButton"
     )
     element.click()
 
@@ -125,7 +125,7 @@ def enable_privacy_settings(driver: WebDriver):
         secondary_checkbox.click()
 
     # driver.start_activity(APP_PACKAGE_NAME, APP_ACTIVITY_NAME)
-    # driver.activate_app("com.ttt246.puppet")
+    # driver.activate_app(f"{APP_PACKAGE_NAME}")
     # These sleeps are harsh, however are now needed till will fix the activity which brings up settings by default
     # Once thats fixed, we can activate the app back it should resume as is, without the back button
 

--- a/e2e_tests/test_sauce_labs.py
+++ b/e2e_tests/test_sauce_labs.py
@@ -31,7 +31,7 @@ def create_android_driver(sauce_labs=False):
     capabilities = dict(
         platformName="Android",
         automationName="uiautomator2",
-        deviceName="Android",
+        deviceName="Google_Pixel_3a_real",
         appPackage=APP_PACKAGE_NAME,
         appActivity=APP_ACTIVITY_NAME,
         language="en",
@@ -51,9 +51,9 @@ def create_android_driver(sauce_labs=False):
         capabilities["sauce:options"]["build"] = f"puppet-build-{BUILD_STAGE}"
         capabilities["sauce:options"]["name"] = "Test Android"
         capabilities["appium:app"] = "storage:filename=app-release-unsigned.apk"
-        capabilities["appium:deviceName"] = "Android GoogleAPI Emulator"
+        capabilities["appium:deviceName"] = "Google_Pixel_3a_real"
 
-        connection_url = "https://ondemand.us-west-1.saucelabs.com:443/wd/hub"
+        connection_url = SAUCE_LABS_URL
     else:
         connection_url = APPIUM_SERVER_URL
 
@@ -143,20 +143,20 @@ class TestAppium(unittest.TestCase):
 
             save_server_settings(driver)
 
-            element = driver.find_element(by=AppiumBy.XPATH, value='//*[@text="Tab 4"]')
-            element.click()
+            find_and_click(driver, by_selector=AppiumBy.XPATH, selector_value='//*[@text="Tab 4"]')
             element = driver.find_element(
-                by=AppiumBy.XPATH, value="//android.widget.EditText[@hint='UID']"
+                by=AppiumBy.XPATH, value="//*[@text='UID']/following-sibling::android.widget.EditText"
             )
             element.send_keys(TEST_UUID)
             element = driver.find_element(
-                by=AppiumBy.XPATH, value="//android.widget.EditText[@hint='Command']"
+                by=AppiumBy.XPATH, value="//*[@text='Command']/following-sibling::android.widget.EditText"
             )
             element.send_keys("test")
             element = driver.find_element(
                 by=AppiumBy.XPATH, value='//*[@text="Submit"]'
             )
             element.click()
+            driver.execute_script("sauce:job-result=passed")
 
 
 if __name__ == "__main__":

--- a/e2e_tests/test_sauce_labs.py
+++ b/e2e_tests/test_sauce_labs.py
@@ -143,13 +143,17 @@ class TestAppium(unittest.TestCase):
 
             save_server_settings(driver)
 
-            find_and_click(driver, by_selector=AppiumBy.XPATH, selector_value='//*[@text="Tab 4"]')
+            find_and_click(
+                driver, by_selector=AppiumBy.XPATH, selector_value='//*[@text="Tab 4"]'
+            )
             element = driver.find_element(
-                by=AppiumBy.XPATH, value="//*[@text='UID']/following-sibling::android.widget.EditText"
+                by=AppiumBy.XPATH,
+                value="//*[@text='UID']/following-sibling::android.widget.EditText",
             )
             element.send_keys(TEST_UUID)
             element = driver.find_element(
-                by=AppiumBy.XPATH, value="//*[@text='Command']/following-sibling::android.widget.EditText"
+                by=AppiumBy.XPATH,
+                value="//*[@text='Command']/following-sibling::android.widget.EditText",
             )
             element.send_keys("test")
             element = driver.find_element(

--- a/e2e_tests/test_sauce_labs.py
+++ b/e2e_tests/test_sauce_labs.py
@@ -93,7 +93,7 @@ def enable_accessibility_settings(driver: WebDriver):
     element = find_and_click(
         driver,
         by_selector=AppiumBy.ID,
-        selector_value=f"{APP_PACKAGE_NAME}:id/accessibilitySettings"
+        selector_value=f"{APP_PACKAGE_NAME}:id/accessibilitySettings",
     )
     element = find_and_click(
         driver,

--- a/e2e_tests/test_sauce_labs.py
+++ b/e2e_tests/test_sauce_labs.py
@@ -118,6 +118,7 @@ def enable_privacy_settings(driver: WebDriver):
     # These sleeps are harsh, however are now needed till will fix the activity which brings up settings by default
     # Once thats fixed, we can activate the app back it should resume as is, without the back button
 
+    time.sleep(1)
     driver.back()
     time.sleep(1)
     driver.back()

--- a/e2e_tests/utils.py
+++ b/e2e_tests/utils.py
@@ -1,4 +1,5 @@
 from selenium.webdriver.remote.webdriver import WebDriver
+from selenium.common.exceptions import TimeoutException
 
 
 def wait_for_element(
@@ -7,12 +8,14 @@ def wait_for_element(
     from selenium.webdriver.support.wait import WebDriverWait
     from selenium.webdriver.support import expected_conditions as EC
 
+    element = None
+
     try:
         element = WebDriverWait(driver, timeout).until(
             EC.presence_of_element_located((by_selector, selector_value))
         )
 
-    except:
+    except TimeoutException:
         element = None
     finally:
         return element
@@ -21,4 +24,3 @@ def wait_for_element(
 def find_and_click(driver: WebDriver, by_selector: str, selector_value: str):
     element = driver.find_element(by=by_selector, value=selector_value)
     element.click()
-    return element

--- a/e2e_tests/utils.py
+++ b/e2e_tests/utils.py
@@ -1,0 +1,24 @@
+from selenium.webdriver.remote.webdriver import WebDriver
+
+
+def wait_for_element(
+    driver: WebDriver, by_selector: str, selector_value: str, timeout: int = 2
+):
+    from selenium.webdriver.support.wait import WebDriverWait
+    from selenium.webdriver.support import expected_conditions as EC
+
+    try:
+        element = WebDriverWait(driver, timeout).until(
+            EC.presence_of_element_located((by_selector, selector_value))
+        )
+
+    except:
+        element = None
+    finally:
+        return element
+
+
+def find_and_click(driver: WebDriver, by_selector: str, selector_value: str):
+    element = driver.find_element(by=by_selector, value=selector_value)
+    element.click()
+    return element

--- a/e2e_tests/utils.py
+++ b/e2e_tests/utils.py
@@ -23,4 +23,5 @@ def wait_for_element(
 
 def find_and_click(driver: WebDriver, by_selector: str, selector_value: str):
     element = driver.find_element(by=by_selector, value=selector_value)
-    element.click()
+    if element:
+        element.click()

--- a/puppet/README.md
+++ b/puppet/README.md
@@ -6,7 +6,7 @@ To understand tests or
 To understand how to build an apk. This is where our releases are generated
 ## Description
 
-Puppet is an Android app that allows users to automate and control various actions on their device using an Accessibility Service. The app is designed to interact with the device's user interface, perform clicks, scroll, type, and execute custom intents based on the commands received from a remote server. Puppet is useful for automating repetitive tasks, testing applications, and more.
+Puppet is an Android app that allows users to automate and control various actions on their device using an Accessibility Service. The app is designed to interact with the device's user interface, perform clicks, scroll, type, switch to package and execute custom intents based on the commands received from a remote server. Puppet is useful for automating repetitive tasks, testing applications, and more.
 
 ## Development
 
@@ -17,6 +17,7 @@ Puppet is an Android app that allows users to automate and control various actio
 - **Remote Control:** The app communicates with a remote server to receive commands and send event logs.
 - **Click, Scroll, and Type:** Puppet can simulate clicks, scroll up and down, and type text into input fields based on the commands received from the server.
 - **Custom Intents:** The app can execute custom intents sent from the server, allowing users to control other applications on the device.
+- **Package:** The app can launch main activity of a package (e.g. youtube, whatsapp etc), allowing users to control other applications on the device.
 - **Heartbeat Mechanism:** Puppet sends event logs and retrieves commands from the server periodically using a heartbeat mechanism.
 - **Notification:** The app runs in the background and shows a persistent notification to indicate that the service is active.
 

--- a/puppet/app/src/main/java/com/ttt246/puppet/PuppetAS.kt
+++ b/puppet/app/src/main/java/com/ttt246/puppet/PuppetAS.kt
@@ -106,6 +106,7 @@ open class PuppetAS : AccessibilityService() {
             when {
                 isIntentCommand(command) -> executeIntentCommand(command)
                 isAccCommand(command) -> executeAccCommand(command)
+                isSwitchAppCommand(command) -> executeSwitchAppCommand(command)
                 else -> Log.e("PuppetAS", "Invalid command: $command")
             }
         }
@@ -119,7 +120,12 @@ open class PuppetAS : AccessibilityService() {
         return command.startsWith("acc:")
     }
 
-     fun executeAccCommand(command: String) {
+    fun isSwitchAppCommand(command: String): Boolean {
+        return command.startsWith("switch:")
+    }
+
+
+    fun executeAccCommand(command: String) {
         val accCommand = command.removePrefix("acc:")
         Log.i("PuppetAS", "Executing Acc command: $accCommand")
 
@@ -248,6 +254,23 @@ open class PuppetAS : AccessibilityService() {
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         startActivity(intent)
     }
+
+    fun executeSwitchAppCommand(command: String) {
+        val packageName = command.removePrefix("switch:")
+        Log.i("PuppetAS", "Executing Switch app command: $packageName")
+//        val intent = packageManager.getLaunchIntentForPackage(packageName)
+        val launchIntent = Intent(Intent.ACTION_MAIN)
+        launchIntent.addCategory(Intent.CATEGORY_LAUNCHER)
+        launchIntent.setPackage(packageName)
+        launchIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        if (launchIntent != null)
+            try {
+                startActivity(launchIntent)
+            } catch (e: Exception) {
+                Log.i("PuppetAS", "Error switching to the package: ${e.message}")
+            }
+    }
+
 
     private var lastOutput: String? = null
 


### PR DESCRIPTION
Added switch command to switch to the instructed package. 
The launch-able activity is the main activity from category launcher.
Tested the command with camera and youtube application. 
In case of a wrong package name or activity of the package couldn't be started, the exception is handled and service continues as is.
Demo:
![Screen Recording](https://github.com/posix4e/puppet/assets/2462783/281956ba-b27a-4399-ae9e-888926274fcc)
