### PR TITLE
BuildConifg (release, debug) for UUID and SERVER_URL

### DIFF
--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -51,10 +51,16 @@ jobs:
 
         # Create APK Debug
       - name: Build apk debug project (APK) - ${{ env.main_project_module }} module
+        env:
+          UUID: ${{ secrets.UUID}}
+          SERVER_URL: ${{ secrets.SERVER_URL }}
         run: ./gradlew assembleDebug
 
         # Create APK Release
       - name: Build apk release project (APK) - ${{ env.main_project_module }} module
+        env:
+          UUID: ${{ secrets.RELEASE_UUID}}
+          SERVER_URL: ${{ secrets.RELEASE_SERVER_URL }}
         run: ./gradlew assemble
 
         # Create Bundle AAB Release

--- a/puppet/app/build.gradle
+++ b/puppet/app/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace 'com.ttt246.puppet'
-    compileSdkVersion 33
+    compileSdk 33
     kotlinOptions {
         jvmTarget = "1.8"
     }
@@ -28,10 +28,27 @@ android {
         }
     }
 
+    buildFeatures {
+        buildConfig = true
+    }
+
     buildTypes {
+        def DEFAULT_SERVER_URL = '"https://posix4e-puppet.hf.space"'
+        // This is a non existent UUID, meant to be a placeholder so that build wont yell
+        def DEFAULT_UUID = '"123456789012345"'
+
+        debug {
+            buildConfigField("String", "SERVER_URL", System.getenv("SERVER_URL") ?: DEFAULT_SERVER_URL)
+            buildConfigField("String", "UUID", System.getenv("UUID") ?: DEFAULT_UUID)
+            applicationIdSuffix ".debug"
+        }
+
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+
+            buildConfigField("String", "SERVER_URL", System.getenv("SERVER_URL") ?: '""')
+            buildConfigField("String", "UUID", System.getenv("UUID") ?: '""')
         }
     }
 

--- a/puppet/app/src/main/java/com/ttt246/puppet/ChatterAct.kt
+++ b/puppet/app/src/main/java/com/ttt246/puppet/ChatterAct.kt
@@ -3,6 +3,8 @@ package com.ttt246.puppet
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
+import android.content.SharedPreferences
+import android.os.Build
 import android.os.Bundle
 import android.preference.PreferenceManager
 import android.provider.Settings
@@ -12,12 +14,20 @@ import androidx.appcompat.app.AppCompatActivity
 
 class ChatterAct : AppCompatActivity() {
     private lateinit var webView: WebView
+    private lateinit var sharedPreferences: SharedPreferences
+
     private val TAG = "ChatterActLog"
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
         supportActionBar?.hide()
+
+        sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
+        val editor = sharedPreferences.edit()
+        editor.putString("SERVER_URL", BuildConfig.SERVER_URL)
+        editor.putString("UUID", BuildConfig.UUID)
+        editor.apply()
 
         val accessibilitySettingsBtn: Button = findViewById(R.id.accessibilitySettings)
         accessibilitySettingsBtn.setOnClickListener {


### PR DESCRIPTION
This embeds debug and release UUID and SERVER_URL as part of the build process.
The UUID and SERVER_URL are read from System Environment variable, falling back to empty string if not configured.
From github actions, following environment variables are fetched.
- UUID, SERVER_URL (for debug)
- RELEASE_UUID, RELEASE_SERVER_URL (for release)

Once we introduce staging environment, it makes sense to separate out the github workflows which refer different environments in github action.

As shows in the GIF, by default the app will now have SERVER_URL and UUID set in the settings. Overriding that will save it back to preferences.

![BuildType](https://github.com/posix4e/puppet/assets/2462783/b4394b73-e5d3-4efa-8cb4-66f4aaa59049)